### PR TITLE
Fix issues with test/llvmDebug not working with paratest

### DIFF
--- a/test/llvmDebug/llvmDebug_test.py
+++ b/test/llvmDebug/llvmDebug_test.py
@@ -1,17 +1,23 @@
+#!/usr/bin/env python
+
 # Python test script to verify the llvm debug info
 # is generated properly during Chapel compilation
 
-import os, subprocess
+import os, subprocess, sys
 
-chpl_home = os.environ['CHPL_HOME']
-llvm_tool_path = chpl_home + os.sep + 'third-party/llvm/install/linux64-gnu/bin'
+chpl_home = sys.argv[1]
+platform = sys.argv[2]
+compiler = sys.argv[3]
+
+plat_comp = platform + '-' + compiler
+llvm_tool_path = chpl_home + '/third-party/llvm/install/' + plat_comp + '/bin'
 build_options = '--baseline --llvm -g'
 source_path = os.getcwd() #same as target path
 source = source_path + os.sep + 'llvmDebug_test.chpl'
 target = source_path + os.sep + 'llvmDebug_test'
 
 # Build Chapel Test Program
-Command_build = 'chpl ' + build_options + ' ' + source + ' -o ' + target
+Command_build = chpl_home + '/bin/' + platform + '/chpl ' + build_options + ' ' + source + ' -o ' + target
 if os.system(Command_build) == 0:
     print 'Build Succeeded'
 else:

--- a/test/llvmDebug/sub_test
+++ b/test/llvmDebug/sub_test
@@ -2,6 +2,8 @@
 
 LLVM=`$CHPL_HOME/util/chplenv/chpl_llvm.py`
 PLAT=`$CHPL_HOME/util/chplenv/chpl_platform.py --target`
+HOST=`$CHPL_HOME/util/chplenv/chpl_platform.py --host`
+COMP=`$CHPL_HOME/util/chplenv/chpl_compiler.py --host`
 
 # We test it only if we're on linux64 with LLVM
 if [ "$LLVM" != "llvm" ]; then
@@ -15,11 +17,12 @@ exit 0;
 fi
 
 
-python llvmDebug_test.py > llvmDebug_test.out.tmp
+rm llvmDebug_test.out.tmp
+python llvmDebug_test.py "$CHPL_HOME" "$HOST" "$COMP" > llvmDebug_test.out.tmp 2>&1
 if ! diff llvmDebug_test.out.tmp llvmDebug_test.good; then
 echo "[Error matching debug info for llvmDebug_test]";
 else
 echo "[Success matching debug info for llvmDebug_test]";
-fi
 rm llvmDebug_test.out.tmp
+fi
 rm llvmDebug_test


### PR DESCRIPTION
I was seeing problems where 'chpl' couldn't be found.
I fixed it by passing the relevant configuration snippets
as arguments to llvmDebug_test.py. Arguably it would
be better for llvmDebug_test.py to get these from
the environment, but it's working now.